### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,5 +1,8 @@
 name: Convert images to WebP (In-place)
 
+permissions:
+  contents: write
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/autoboat-vt/website/security/code-scanning/2](https://github.com/autoboat-vt/website/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/manual.yml` so the workflow does not inherit potentially broad defaults.  
Best fix without changing behavior: define permissions at the workflow root (applies to all jobs), granting only what is required for current steps. Since the workflow checks out code and pushes commits, set:

- `contents: write`

This preserves existing functionality (`git push`) while restricting token scope to only repository contents access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
